### PR TITLE
feat: add multiple output window and vim.fn.termopen

### DIFF
--- a/lua/mix/config.lua
+++ b/lua/mix/config.lua
@@ -11,16 +11,22 @@ M.possible_values = {
 
 function M.validate_config(config)
     if not utils.has_value(M.possible_values.window, config.window) then
-        error(table.concat({ "opt window = '", config.window,
-            "' is not valid. valid options are: ", table.concat(M.possible_values.window, " | ") }))
+        local message = { "opt window = '", config.window,
+            "' is not valid. valid options are: ", table.concat(M.possible_values.window, " | ") }
+        vim.notify(table.concat(message), vim.log.levels.ERROR)
+        return false
     end
+
+    return true
 end
 
 function M.get_config(opts)
     local config = opts or {}
     config = vim.tbl_extend("force", M.defaults, config)
 
-    M.validate_config(config)
+    if not M.validate_config(config) then
+        error("invalid configuration, check :messages.")
+    end
 
     return config
 end

--- a/lua/mix/config.lua
+++ b/lua/mix/config.lua
@@ -1,0 +1,24 @@
+local utils = require("mix.utils")
+local M = {}
+
+M.defaults = {
+    window = "floating"
+}
+
+function M:validate_config(config)
+    if not utils.has_value({ "floating", "horizontal", "vertical" }, config.window) then
+        error(table.concat({ "opt window = '", config["window"],
+            "' is not valid. valid options are: stdout, floating, horizontal, and vertical" }))
+    end
+end
+
+function M:get_config(opts)
+    local config = opts or {}
+    config = vim.tbl_extend("force", M.defaults, config)
+
+    M:validate_config(config)
+
+    return config
+end
+
+return M

--- a/lua/mix/config.lua
+++ b/lua/mix/config.lua
@@ -20,7 +20,7 @@ function M.get_config(opts)
     local config = opts or {}
     config = vim.tbl_extend("force", M.defaults, config)
 
-    M:validate_config(config)
+    M.validate_config(config)
 
     return config
 end

--- a/lua/mix/config.lua
+++ b/lua/mix/config.lua
@@ -5,14 +5,18 @@ M.defaults = {
     window = "floating"
 }
 
-function M:validate_config(config)
-    if not utils.has_value({ "floating", "horizontal", "vertical" }, config.window) then
-        error(table.concat({ "opt window = '", config["window"],
-            "' is not valid. valid options are: stdout, floating, horizontal, and vertical" }))
+M.possible_values = {
+    window = { "floating", "horizontal", "vertical" }
+}
+
+function M.validate_config(config)
+    if not utils.has_value(M.possible_values.window, config.window) then
+        error(table.concat({ "opt window = '", config.window,
+            "' is not valid. valid options are: ", table.concat(M.possible_values.window, " | ") }))
     end
 end
 
-function M:get_config(opts)
+function M.get_config(opts)
     local config = opts or {}
     config = vim.tbl_extend("force", M.defaults, config)
 

--- a/lua/mix/init.lua
+++ b/lua/mix/init.lua
@@ -1,5 +1,6 @@
 local mix = require("mix.wrapper")
 local window = require("mix.window")
+local utils = require("mix.utils")
 
 local M = {}
 
@@ -8,7 +9,7 @@ function M_complete(_, line, _)
     return completions
 end
 
-function M:commands()
+function M:commands(opts)
     local mix_complete_options = {
         nargs = "*",
         range = true,
@@ -24,6 +25,13 @@ function M:commands()
         end,
         {}
     )
+end
+
+function M:validate_opts(opts)
+    if not utils.has_value({ "stdout", "floating", "horizontal", "vertical" }, opts["window"]) then
+        error(table.concat({ "opt window = '", opts["window"],
+            "' is not valid. valid options are: stdout, floating, horizontal, and vertical" }))
+    end
 end
 
 function M.run(opts)
@@ -45,13 +53,24 @@ function M.run(opts)
     )
 end
 
-function M.setup()
+function M.setup(user_opts)
     if not vim.g.mix_nvim_buffer then
         vim.g.mix_nvim_buffer = vim.api.nvim_create_buf(false, true)
         vim.api.nvim_buf_set_name(vim.g.mix_nvim_buffer, "mix.nvim output panel")
     end
 
-    M:commands()
+    local opts = user_opts or {}
+    local default_opts = {
+        window = "stdout"
+    }
+
+    local final_opts = vim.tbl_extend("force", default_opts, opts)
+
+    M:validate_opts(final_opts)
+
+    vim.pretty_print(final_opts)
+
+    M:commands(final_opts)
 end
 
 return M

--- a/lua/mix/init.lua
+++ b/lua/mix/init.lua
@@ -1,5 +1,4 @@
 local mix = require("mix.wrapper")
-local window = require("mix.window")
 local config = require("mix.config")
 
 local M = {}
@@ -31,17 +30,10 @@ function M.run(opts)
         return
     end
 
-    window.open_window(vim.g.mix_nvim_buffer, vim.g.mix_nvim_config)
-
-    mix.run(vim.g.mix_nvim_buffer, action, args)
+    mix.run(action, args)
 end
 
 function M.setup(user_opts)
-    if not vim.g.mix_nvim_buffer then
-        vim.g.mix_nvim_buffer = vim.api.nvim_create_buf(false, true)
-        vim.api.nvim_buf_set_name(vim.g.mix_nvim_buffer, "mix.nvim output panel")
-    end
-
     vim.g.mix_nvim_config = config.get_config(user_opts)
 
     M.commands()

--- a/lua/mix/init.lua
+++ b/lua/mix/init.lua
@@ -16,10 +16,7 @@ function M.commands()
     }
     vim.api.nvim_create_user_command("Mix", M.run, mix_complete_options)
     vim.api.nvim_create_user_command("M", M.run, mix_complete_options)
-    vim.api.nvim_create_user_command("MixRefreshCompletions", function()
-        mix.refresh_completions()
-        vim.notify("Mix commands refreshed")
-    end, {})
+    vim.api.nvim_create_user_command("MixRefreshCompletions", mix.refresh_completions, {})
 end
 
 function M.run(opts)

--- a/lua/mix/init.lua
+++ b/lua/mix/init.lua
@@ -9,7 +9,7 @@ function M_complete(_, line, _)
     return completions
 end
 
-function M:commands()
+function M.commands()
     local mix_complete_options = {
         nargs = "*",
         range = true,
@@ -44,7 +44,7 @@ function M.setup(user_opts)
 
     vim.g.mix_nvim_config = config.get_config(user_opts)
 
-    M:commands()
+    M.commands()
 end
 
 return M

--- a/lua/mix/init.lua
+++ b/lua/mix/init.lua
@@ -1,6 +1,6 @@
 local mix = require("mix.wrapper")
 local window = require("mix.window")
-local utils = require("mix.utils")
+local config = require("mix.config")
 
 local M = {}
 
@@ -9,7 +9,7 @@ function M_complete(_, line, _)
     return completions
 end
 
-function M:commands(opts)
+function M:commands()
     local mix_complete_options = {
         nargs = "*",
         range = true,
@@ -27,13 +27,6 @@ function M:commands(opts)
     )
 end
 
-function M:validate_opts(opts)
-    if not utils.has_value({ "stdout", "floating", "horizontal", "vertical" }, opts["window"]) then
-        error(table.concat({ "opt window = '", opts["window"],
-            "' is not valid. valid options are: stdout, floating, horizontal, and vertical" }))
-    end
-end
-
 function M.run(opts)
     local action = table.remove(opts.fargs, 1)
     local args = opts.fargs
@@ -42,15 +35,9 @@ function M.run(opts)
         return
     end
 
-    window.open_floating_window(vim.g.mix_nvim_buffer)
+    window.open_window(vim.g.mix_nvim_buffer, vim.g.mix_nvim_config)
 
-    local result = mix.run(action, args)
-
-    vim.api.nvim_buf_set_lines(
-        vim.g.mix_nvim_buffer,
-        0, -1, false,
-        vim.split(result, "\n")
-    )
+    mix.run(vim.g.mix_nvim_buffer, action, args)
 end
 
 function M.setup(user_opts)
@@ -59,18 +46,9 @@ function M.setup(user_opts)
         vim.api.nvim_buf_set_name(vim.g.mix_nvim_buffer, "mix.nvim output panel")
     end
 
-    local opts = user_opts or {}
-    local default_opts = {
-        window = "stdout"
-    }
+    vim.g.mix_nvim_config = config.get_config(user_opts)
 
-    local final_opts = vim.tbl_extend("force", default_opts, opts)
-
-    M:validate_opts(final_opts)
-
-    vim.pretty_print(final_opts)
-
-    M:commands(final_opts)
+    M:commands()
 end
 
 return M

--- a/lua/mix/utils.lua
+++ b/lua/mix/utils.lua
@@ -1,0 +1,13 @@
+local M = {}
+
+function M.has_value(tab, val)
+    for _, value in ipairs(tab) do
+        if value == val then
+            return true
+        end
+    end
+
+    return false
+end
+
+return M

--- a/lua/mix/window.lua
+++ b/lua/mix/window.lua
@@ -2,17 +2,14 @@ local popup = require("plenary.popup")
 
 local M = {}
 
+
 function M.open_floating_window(buf)
     local columns = vim.o.columns
     local lines = vim.o.lines
     local width = math.ceil(columns * 0.8)
     local height = math.ceil(lines * 0.8 - 4)
-    -- local left = math.ceil((columns - width) * 0.5)
-    -- local top = math.ceil((lines - height) * 0.5 - 1)
 
-    local bufnr = buf or vim.api.nvim_create_buf(false, true)
-
-    local win_id = popup.create(bufnr, {
+    local _ = popup.create(buf, {
         line = 0,
         col = 0,
         minwidth = width,
@@ -21,8 +18,28 @@ function M.open_floating_window(buf)
         padding = { 2, 2, 2, 2 },
         zindex = 10,
     })
+end
 
-    return bufnr
+function M.open_vertical_window(buf)
+    vim.cmd("sp")
+    vim.api.nvim_win_set_buf(0, buf)
+    vim.api.nvim_win_set_height(0, 30)
+end
+
+function M.open_horizontal_window(buf)
+    vim.cmd("sp")
+    vim.api.nvim_win_set_buf(0, buf)
+    vim.api.nvim_win_set_height(0, 30)
+end
+
+function M.open_window(buf, config)
+    local windows = {
+        floating = M.open_floating_window,
+        vertical = M.open_vertical_window,
+        horizontal = M.open_horizontal_window
+    }
+
+    windows[config.window](buf)
 end
 
 return M

--- a/lua/mix/window.lua
+++ b/lua/mix/window.lua
@@ -3,43 +3,54 @@ local popup = require("plenary.popup")
 local M = {}
 
 
-function M.open_floating_window(buf)
+function M.open_floating_window()
+    local buf = vim.api.nvim_create_buf(false, true)
+
     local columns = vim.o.columns
     local lines = vim.o.lines
     local width = math.ceil(columns * 0.8)
     local height = math.ceil(lines * 0.8 - 4)
 
-    local _ = popup.create(buf, {
+    local win_id = popup.create(buf, {
         line = 0,
         col = 0,
         minwidth = width,
         minheight = height,
         border = {},
+        borderchars = {"-", "|", "-", "|", "┌", "┐", "┘", "└"},
         padding = { 2, 2, 2, 2 },
         zindex = 10,
     })
+
+    return buf, win_id
 end
 
-function M.open_vertical_window(buf)
-    vim.cmd("sp")
-    vim.api.nvim_win_set_buf(0, buf)
-    vim.api.nvim_win_set_height(0, 30)
+function M.open_vertical_window()
+    vim.cmd("bot vnew")
+
+    return vim.api.nvim_get_current_buf(), vim.api.nvim_get_current_win()
 end
 
-function M.open_horizontal_window(buf)
-    vim.cmd("sp")
-    vim.api.nvim_win_set_buf(0, buf)
-    vim.api.nvim_win_set_height(0, 30)
+function M.open_horizontal_window()
+    vim.cmd("top new")
+
+    return vim.api.nvim_get_current_buf(), vim.api.nvim_get_current_win()
 end
 
-function M.open_window(buf, config)
+function M.open_window(config)
     local windows = {
         floating = M.open_floating_window,
         vertical = M.open_vertical_window,
         horizontal = M.open_horizontal_window
     }
 
-    windows[config.window](buf)
+    local buf_id, win_id = windows[config.window]()
+
+    vim.bo[buf_id].filetype = "MixOutputPanel"
+    vim.wo[win_id].number = false
+    vim.wo[win_id].relativenumber = false
+
+    return buf_id
 end
 
 return M

--- a/lua/mix/wrapper.lua
+++ b/lua/mix/wrapper.lua
@@ -1,4 +1,5 @@
 local mix_exs = require("mix.exs")
+local window = require("mix.window")
 
 local M = {
     mix_exs_path_cache = nil,
@@ -33,26 +34,30 @@ function M.load_completions(cli_input)
     return vim.g.mix_complete_list
 end
 
-function M.run(buf, action, args)
+function M.run(action, args)
     local args_as_str = table.concat(args, " ")
 
-    -- local cd_cmd = ""
-    -- local mix_exs_path = M.mix_exs()
-    -- if mix_exs_path then
-    --     cd_cmd = table.concat({ "cd", mix_exs_path, "&&" }, " ")
-    -- end
+    local cd_cmd = ""
+    local mix_exs_path = M.mix_exs()
 
-    local cmd = {
+
+    if mix_exs_path then
+        cd_cmd = mix_exs_path
+    end
+
+    local cmd = table.concat({
         "mix",
         action,
         args_as_str
-    }
+    }, " ")
 
-    vim.fn.jobstart(cmd, {
-        stdout_buffered = true,
-        on_stdout = function(_, data)
-            if data then
-                vim.api.nvim_buf_set_lines(buf, 0, -1, false, data)
+    window.open_window(vim.g.mix_nvim_config)
+
+    vim.fn.termopen(cmd, {
+        cwd = cd_cmd,
+        on_exit = function()
+            if action == "deps.get" then
+                M.refresh_completions()
             end
         end
     })

--- a/lua/mix/wrapper.lua
+++ b/lua/mix/wrapper.lua
@@ -33,17 +33,29 @@ function M.load_completions(cli_input)
     return vim.g.mix_complete_list
 end
 
-function M.run(action, args)
+function M.run(buf, action, args)
     local args_as_str = table.concat(args, " ")
 
-    local cd_cmd = ''
-    local mix_exs_path = M.mix_exs()
-    if mix_exs_path then
-        cd_cmd = table.concat({ 'cd', mix_exs_path, '&&' }, ' ')
-    end
+    -- local cd_cmd = ''
+    -- local mix_exs_path = M.mix_exs()
+    -- if mix_exs_path then
+    --     cd_cmd = table.concat({ 'cd', mix_exs_path, '&&' }, ' ')
+    -- end
 
-    local cmd = { cd_cmd, "mix", action, args_as_str }
-    return run_command(table.concat(cmd, " "))
+    local cmd = {
+        "mix",
+        action,
+        args_as_str
+    }
+
+    vim.fn.jobstart(cmd, {
+        stdout_buffered = true,
+        on_stdout = function(_, data)
+            if data then
+                vim.api.nvim_buf_set_lines(buf, 0, -1, false, data)
+            end
+        end
+    })
 end
 
 function M.mix_exs()

--- a/lua/mix/wrapper.lua
+++ b/lua/mix/wrapper.lua
@@ -60,7 +60,7 @@ end
 
 function M.mix_exs()
     if not M.mix_exs_path_cache then
-        local mix_ops = mix_exs:path_mix_exs()
+        local mix_ops = mix_exs.path_mix_exs()
         if mix_ops.file_exists then
             M.mix_exs_path_cache = mix_ops.mix_dir
         end

--- a/lua/mix/wrapper.lua
+++ b/lua/mix/wrapper.lua
@@ -5,14 +5,9 @@ local M = {
     mix_exs_path_cache = nil,
 }
 
-local function run_command(cmd)
-    local result = vim.fn.system(cmd)
-    return result
-end
-
 function M.refresh_completions()
     local cmd = "mix help | awk -F ' ' '{printf \"%s\\n\", $2}' | grep -E \"[^-#]\\w+\""
-    vim.g.mix_complete_list = run_command(cmd)
+    vim.g.mix_complete_list = vim.fn.system(cmd)
     vim.notify("Mix commands refreshed")
 end
 

--- a/lua/mix/wrapper.lua
+++ b/lua/mix/wrapper.lua
@@ -13,6 +13,7 @@ end
 function M.refresh_completions()
     local cmd = "mix help | awk -F ' ' '{printf \"%s\\n\", $2}' | grep -E \"[^-#]\\w+\""
     vim.g.mix_complete_list = run_command(cmd)
+    vim.notify("Mix commands refreshed")
 end
 
 function M.load_completions(cli_input)

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -1,0 +1,40 @@
+local stub = require("luassert.stub")
+
+local config = require("mix.config")
+
+describe("config", function ()
+   it("should accept valid window opts", function ()
+       assert.is_true(config.validate_config({
+           window = "floating"
+       }))
+
+       assert.is_true(config.validate_config({
+           window = "vertical"
+       }))
+
+       assert.is_true(config.validate_config({
+           window = "horizontal"
+       }))
+   end)
+
+   it("should failed when a unvalid window opt is passed", function ()
+       assert.is_true(not config.validate_config({
+           window = "different_window"
+       }))
+   end)
+
+
+   it("should return default options when user options is empty", function ()
+       local user_opts = config.get_config({})
+
+       assert.equal(config.defaults.window, user_opts.window)
+   end)
+
+   it("should merge options", function ()
+       local user_opts = config.get_config({
+           window = "floating"
+       })
+
+       assert.equal("floating", user_opts.window)
+   end)
+end)

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -6,10 +6,6 @@ local window = require("mix.window")
 local config = require("mix.config")
 
 describe("init", function()
-    before_each(function()
-        vim.g.mix_nvim_buffer = nil
-    end)
-
     it("should setup plugin", function()
         local s = stub(config, "get_config", {})
 

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -3,6 +3,7 @@ local stub = require("luassert.stub")
 local mix = require("mix")
 local wrapper = require("mix.wrapper")
 local window = require("mix.window")
+local config = require("mix.config")
 
 describe("init", function()
     before_each(function()
@@ -10,16 +11,13 @@ describe("init", function()
     end)
 
     it("should setup plugin", function()
-        local s_create_buf = stub(vim.api, "nvim_create_buf", 55)
-        local s_nvim_set_buf_name = stub(vim.api, "nvim_buf_set_name")
+        local s = stub(config, "get_config", {})
 
         mix.setup()
 
-        assert.equal(55, vim.g.mix_nvim_buffer)
-        assert.stub(vim.api.nvim_create_buf).was_called()
+        assert.stub(config.get_config).was_called()
 
-        s_create_buf:revert()
-        s_nvim_set_buf_name:revert()
+        s:revert()
     end)
 
     it("should create M, Mix and MixRefreshCompletions commands", function()
@@ -43,21 +41,16 @@ describe("init", function()
     end)
 
     it("should run the mix command and send the output to a window", function()
-        local s_run = stub(wrapper, "run", "output mocked\ntest")
-        local s_nvim_buf_set_lines = stub(vim.api, "nvim_buf_set_lines")
-        local s_open_floating_window = stub(window, "open_floating_window")
+        local s_open_window = stub(window, "open_window")
 
-        vim.g.mix_nvim_buffer = 32
+        vim.g.mix_nvim_config = { window = "floating"  }
+
         mix.run({
             fargs = { "Mix", "deps.get" },
         })
 
-        assert.stub(wrapper.run).was_called()
-        assert.stub(vim.api.nvim_buf_set_lines).was_called()
-        assert.stub(window.open_floating_window).was_called()
+        assert.stub(window.open_window).was_called()
 
-        s_open_floating_window:revert()
-        s_run:revert()
-        s_nvim_buf_set_lines:revert()
+        s_open_window:revert()
     end)
 end)

--- a/tests/wrapper_spec.lua
+++ b/tests/wrapper_spec.lua
@@ -44,11 +44,16 @@ describe("wrapper", function()
     end)
 
     it("should run mix commands successfully", function()
-        local s = stub(wrapper, "mix_exs", cwd .. "/mock")
-        local output = wrapper.run("deps.get", {})
+        vim.g.mix_nvim_config = { window = "floating"  }
+        local s_mix_exs = stub(wrapper, "mix_exs", cwd .. "/mock")
+        local s_termopen = stub(vim.fn, "termopen", {})
 
-        assert.equal("All dependencies are up to date\n", output)
-        s:revert()
+        local _ = wrapper.run("deps.get", {})
+
+        assert.stub(vim.fn.termopen).was_called()
+
+        s_mix_exs:revert()
+        s_termopen:revert()
     end)
 
     it("should resolve mix.exs path when not cached", function()
@@ -77,8 +82,7 @@ describe("wrapper", function()
         exs.mix_exs_path_cache = cwd .. "/mock"
         local path = wrapper.mix_exs()
 
-        assert.equal(cwd .. "/mock", path)
-        assert.equal(cwd .. "/mock", wrapper.mix_exs_path_cache)
+        assert.equal(exs.mix_exs_path_cache, path)
         assert.stub(exs.path_mix_exs).was_not_called()
 
         s:revert()


### PR DESCRIPTION
This PR allows the user to define the type of the output window.
When calling the `mix.setup` the user can now specify the `window` key to be equal to `floating`, `horizontal`, or `vertical`.
Additionally, this PR:
* Replaces the usual way of running the mix commands to `vim.fn.termopen`.
* Move the refresh completions notification to the refresh function itself.
* Fix previous tests.
* Add tests to the config module.

Closes #3.

